### PR TITLE
Remove IRestoreKeyConverter implementation for PluginManager

### DIFF
--- a/Sources/BitcoinCore/Classes/Core/BitcoinCoreBuilder.swift
+++ b/Sources/BitcoinCore/Classes/Core/BitcoinCoreBuilder.swift
@@ -133,7 +133,6 @@ public class BitcoinCoreBuilder {
         let pluginManager = PluginManager(scriptConverter: scriptConverter, logger: logger)
 
         plugins.forEach { pluginManager.add(plugin: $0) }
-        restoreKeyConverterChain.add(converter: pluginManager)
 
         let unspentOutputProvider = UnspentOutputProvider(storage: storage, pluginManager: pluginManager, confirmationsThreshold: confirmationsThreshold)
         var transactionInfoConverter = self.transactionInfoConverter ?? TransactionInfoConverter()

--- a/Sources/BitcoinCore/Classes/Core/Protocols.swift
+++ b/Sources/BitcoinCore/Classes/Core/Protocols.swift
@@ -597,7 +597,7 @@ protocol IIrregularOutputFinder {
     func hasIrregularOutput(outputs: [Output]) -> Bool
 }
 
-public protocol IPlugin {
+public protocol IPlugin : IRestoreKeyConverter {
     var id: UInt8 { get }
     var maxSpendLimit: Int? { get }
     func validate(address: Address) throws
@@ -606,7 +606,10 @@ public protocol IPlugin {
     func isSpendable(unspentOutput: UnspentOutput) throws -> Bool
     func inputSequenceNumber(output: Output) throws -> Int
     func parsePluginData(from: String, transactionTimestamp: Int) throws -> IPluginOutputData
-    func keysForApiRestore(publicKey: PublicKey) throws -> [String]
+}
+
+extension IPlugin {
+    public func bloomFilterElements(publicKey: PublicKey) -> [Data] { [] }
 }
 
 public protocol IPluginManager {

--- a/Sources/BitcoinCore/Classes/Managers/PluginManager.swift
+++ b/Sources/BitcoinCore/Classes/Managers/PluginManager.swift
@@ -112,15 +112,3 @@ extension PluginManager: IPluginManager {
     }
 
 }
-
-extension PluginManager: IRestoreKeyConverter {
-
-    public func keysForApiRestore(publicKey: PublicKey) -> [String] {
-        (try? plugins.flatMap({ try $0.value.keysForApiRestore(publicKey: publicKey) })) ?? []
-    }
-
-    public func bloomFilterElements(publicKey: PublicKey) -> [Data] {
-        []
-    }
-
-}


### PR DESCRIPTION
- Move IRestoreKeyConverter implementation directly to the IPlugin, because not all plugins may need it.